### PR TITLE
Fix broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,12 +43,12 @@
 <h2>
 <a id="developers" class="anchor" href="#developers" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Developers</h2>
 
-<p>Calling all developers! We need you to create some awesome new tweaks using taiHEN! With the new hooking system, the possibilities are endless: cheats, UI tweaks, screen casting, and more. But we need your help is making it all a reality. Get started by downloading the latest kernel enabled <a href="https://github.com/vitasdk/buildscripts">toolchain</a> and the <a href="https://github.com/yifanlu/taiHEN/releases/new">taiHEN library</a>. Check out the <a href="/docs/">API documentation</a> for taiHEN. Join us in the #vitasdk chatroom in FreeNode IRC for help and support.</p>
+<p>Calling all developers! We need you to create some awesome new tweaks using taiHEN! With the new hooking system, the possibilities are endless: cheats, UI tweaks, screen casting, and more. But we need your help is making it all a reality. Get started by downloading the latest kernel enabled <a href="https://github.com/vitasdk/buildscripts">toolchain</a> and the <a href="https://github.com/yifanlu/taiHEN/releases">taiHEN library</a>. Check out the <a href="/docs/">API documentation</a> for taiHEN. Join us in the #vitasdk chatroom in FreeNode IRC for help and support.</p>
 
 <h3>
 <a id="building" class="anchor" href="#building" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Building</h3>
 
-<p>We will add build instructions for plugins here in the future. Right now, just check out how the <a href="https://github.com/henkaku/henkaku/plugin/tree/master/src">HENkaku plugin</a> does it or chat with us in #vitasdk.</p>
+<p>We will add build instructions for plugins here in the future. Right now, just check out how the <a href="https://github.com/henkaku/henkaku/tree/master/plugin">HENkaku plugin</a> does it or chat with us in #vitasdk.</p>
 
 <h3>
 <a id="configuration" class="anchor" href="#configuration" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Configuration</h3>
@@ -89,7 +89,7 @@ ux0:data/tai/shell_plgin.skprx
 <h3>
 <a id="examples" class="anchor" href="#examples" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Examples</h3>
 
-<p>We hope you will read the <a href="/docs/">API documentation</a> to see the full power of taiHEN and the <a href="https://github.com/henkaku/henkaku/plugin/tree/master/src">HENkaku source</a> to see an example usage. However, below are some quick usage examples that demonstrate the power of taiHEN.</p>
+<p>We hope you will read the <a href="/docs/">API documentation</a> to see the full power of taiHEN and the <a href="https://github.com/henkaku/henkaku/tree/master/plugin">HENkaku source</a> to see an example usage. However, below are some quick usage examples that demonstrate the power of taiHEN.</p>
 
 <h4>
 <a id="do-something-on-startup" class="anchor" href="#do-something-on-startup" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Do something on startup</h4>


### PR DESCRIPTION
Note: this now links to the taiHEN releases page, which is currently empty, instead of the taiHEN "new release" page, which is obviously inaccessible to the public