### PR TITLE
 Skip plugins if the user selected Rebuild Database in safe mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,13 +59,13 @@ target_link_libraries(taihen
   taihenparser
   gcc
   SceSysmemForDriver_stub
-  SceSysmemForKernel_stub
+  SceSysmemForKernel_367_stub
   SceSysclibForDriver_stub
-  SceCpuForKernel_stub
+  SceCpuForKernel_367_stub
   SceCpuForDriver_stub
   SceSysrootForKernel_stub
   SceThreadmgrForDriver_stub
-  SceModulemgrForKernel_stub
+  SceModulemgrForKernel_367_stub
   SceModulemgrForDriver_stub
   SceIofilemgrForDriver_stub
   SceSblACMgrForDriver_stub

--- a/hen.c
+++ b/hen.c
@@ -7,6 +7,7 @@
  */
 #include <psp2kern/ctrl.h>
 #include <psp2kern/types.h>
+#include <psp2kern/io/stat.h>
 #include <psp2kern/kernel/sysmem.h>
 #include <string.h>
 #include "error.h"
@@ -350,8 +351,8 @@ static int unload_process_patched(SceUID pid) {
  *             SCE bug, we cannot have > 15 preloaded modules. Instead now we
  *             hook at the point those preloaded modules start.
  *
- *             If the user hold the L button while the application is loading,
- *             plugins will be skipped.
+ *             If the user hold the L button while starting taiHEN or rebuilt database,
+ *             kernel plugins will be skipped.
  *
  * @param[in]  pid   The process being started
  *
@@ -359,6 +360,7 @@ static int unload_process_patched(SceUID pid) {
  */
 static int start_preloaded_modules_patched(SceUID pid) {
   SceCtrlData ctrl;
+  SceIoStat stat;
   int ret;
   char titleid[32];
 
@@ -367,7 +369,8 @@ static int start_preloaded_modules_patched(SceUID pid) {
 
   ksceCtrlPeekBufferPositive(0, &ctrl, 1);
   LOG("buttons held: 0x%08X", ctrl.buttons);
-  if (ctrl.buttons & (SCE_CTRL_LTRIGGER | SCE_CTRL_L1)) {
+  if (ctrl.buttons & (SCE_CTRL_LTRIGGER | SCE_CTRL_L1) ||
+      ksceIoGetstat("ur0:shell/db/dbr.db-err", &stat) >= 0) {
     LOG("skipping plugin loading");
     return ret;
   }

--- a/hen.c
+++ b/hen.c
@@ -352,7 +352,7 @@ static int unload_process_patched(SceUID pid) {
  *             hook at the point those preloaded modules start.
  *
  *             If the user hold the L button while starting taiHEN or rebuilt database,
- *             kernel plugins will be skipped.
+ *             plugins will be skipped.
  *
  * @param[in]  pid   The process being started
  *

--- a/taihen.c
+++ b/taihen.c
@@ -8,6 +8,7 @@
 #include <psp2kern/types.h>
 #include <psp2kern/ctrl.h>
 #include <psp2kern/sblaimgr.h>
+#include <psp2kern/io/stat.h>
 #include <psp2kern/kernel/modulemgr.h>
 #include <psp2kern/kernel/threadmgr.h>
 #include <taihen/parser.h>
@@ -311,8 +312,8 @@ int taiReloadConfigForKernel(int schedule, int load_kernel) {
  *             the kernel environment to be clean, which means that no outside
  *             hooks and patches which may interfere with taiHEN.
  *
- *             If the user hold the L button while starting taiHEN, kernel
- *             plugins will be skipped.
+ *             If the user hold the L button while starting taiHEN or rebuilt database,
+ *             kernel plugins will be skipped.
  *
  * @param[in]  argc  Size of arguments (unused)
  * @param[in]  args  The arguments (unused)
@@ -321,6 +322,7 @@ int taiReloadConfigForKernel(int schedule, int load_kernel) {
  */
 int module_start(SceSize argc, const void *args) {
   SceCtrlData ctrl;
+  SceIoStat stat;
   int ret;
   LOG("starting taihen...");
   ret = proc_map_init();
@@ -345,7 +347,8 @@ int module_start(SceSize argc, const void *args) {
   }
   ksceCtrlPeekBufferPositive(0, &ctrl, 1);
   LOG("buttons held: 0x%08X", ctrl.buttons);
-  if (!(ctrl.buttons & (SCE_CTRL_LTRIGGER | SCE_CTRL_L1))) {
+  if (!(ctrl.buttons & (SCE_CTRL_LTRIGGER | SCE_CTRL_L1)) &&
+      ksceIoGetstat("ur0:shell/db/dbr.db-err", &stat) < 0) {
     ret = plugin_load_config();
     if (ret < 0) {
       LOG("HEN config load failed: %x", ret);


### PR DESCRIPTION
If you have installed a bad plugin on PSTV and ended up in a boot loop, your only choice was to restore the system, since holding L to skip plugins would not work due to the controller not being synchronized yet.
(https://github.com/yifanlu/taiHEN/issues/80)
As a result the PSN activation file will be erased during this procedure and it's a pity if the user hasn't made a backup of it.
This PR handles this bug by giving the ability to boot without plugins enabled by rebuilding the database in safe mode.